### PR TITLE
Make cyclic hash seedable, add new example/test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 CXXFLAGS =  -std=c++11 -fexceptions -pedantic -ggdb -g3 -O2  -Wall -Woverloaded-virtual  -Wsign-promo -Wold-style-cast 
 #-DNDEBUG
-all: unit speedtesting example example2 example3 example64bits example4
+all: unit speedtesting example example2 example3 example64bits example4 example5
 
 SRCS = unit.cpp speedtesting.cpp example.cpp example2.cpp example3.cpp example4.cpp example64bits.cpp
 
@@ -16,7 +16,7 @@ depend:
 	makedepend -- $(CXXFLAGS) -- $(SRCS)
 
 clean:
-	rm -f *.o unit speedtesting example example2 example3 example4 example64bits
+	rm -f *.o unit speedtesting example example2 example3 example4 example64bits example5
 
 HEADERS=cyclichash.h characterhash.h mersennetwister.h rabinkarphash.h generalhash.h threewisehash.h
 unit.o: $(HEADERS)
@@ -25,5 +25,6 @@ example.o: $(HEADERS)
 example2.o: $(HEADERS)
 example3.o: $(HEADERS)
 example4.o: $(HEADERS)
+example5.o: $(HEADERS)
 example64bits.o: $(HEADERS)
 

--- a/characterhash.h
+++ b/characterhash.h
@@ -60,10 +60,26 @@ public:
         } else throw runtime_error("unsupported hash value type");
     }
 
+    CharacterHash(hashvaluetype maxval, uint32 seed1, uint32 seed2) {
+        if(sizeof(hashvaluetype) <=4) {
+            mersenneRNG randomgenerator(maxval);
+            randomgenerator.seed(seed1);
+            for(size_t k =0; k<nbrofchars; ++k)
+                hashvalues[k] = static_cast<hashvaluetype>(randomgenerator());
+        } else if (sizeof(hashvaluetype) == 8) {
+            mersenneRNG randomgenerator(maxval>>32);
+            mersenneRNG randomgeneratorbase((maxval>>32) ==0 ? maxval : 0xFFFFFFFFU);
+            randomgenerator.seed(seed1);
+            randomgeneratorbase.seed(seed2);
+            for(size_t k =0; k<nbrofchars; ++k)
+                hashvalues[k] = static_cast<hashvaluetype>(randomgeneratorbase())
+                                | (static_cast<hashvaluetype>(randomgenerator()) << 32);
+        } else throw runtime_error("unsupported hash value type");
+    }
+
     enum {nbrofchars = 1 << ( sizeof(chartype)*8 )};
 
     hashvaluetype hashvalues[1 << ( sizeof(chartype)*8 )];
 };
 
 #endif
-

--- a/cyclichash.h
+++ b/cyclichash.h
@@ -39,6 +39,20 @@ public:
         }
     }
 
+    CyclicHash(int myn, uint32 seed1, uint32 seed2, int mywordsize=19) :
+        hashvalue(0),
+        n(myn), wordsize(mywordsize),
+        hasher(maskfnc<hashvaluetype>(wordsize), seed1, seed2),
+        mask1(maskfnc<hashvaluetype>(wordsize-1)),
+        myr(n%wordsize),
+        maskn(maskfnc<hashvaluetype>(wordsize-myr))
+    {
+        if(static_cast<uint>(wordsize) > 8*sizeof(hashvaluetype)) {
+            cerr<<"Can't create "<<wordsize<<"-bit hash values"<<endl;
+            throw "abord";
+        }
+    }
+
     void fastleftshiftn(hashvaluetype & x) const {
         x =  ((x & maskn) << myr ) | (x >> (wordsize-myr)) ;
     }

--- a/example5.cpp
+++ b/example5.cpp
@@ -1,0 +1,69 @@
+#include <string>
+#include <memory>
+#include <cassert>
+#include <iostream>
+#include "cyclichash.h"
+
+// Define DNA's complementary nucleotides
+# define nucleotide_complement(ch) ( \
+	(toupper(ch)) == 'A' ? 'T' : \
+	(toupper(ch)) == 'T' ? 'A' : \
+	(toupper(ch)) == 'C' ? 'G' : 'C' \
+)
+
+// A sequence and its reverse complement (such as "GATTACA" and "TGTAATC") are
+// biologically identical and should hash to the same value. A sequence that is
+// equal to its reverse complement is a special case and should be handled
+// accordingly.
+#define canonical_hash(fwd, rev) ( \
+    fwd == rev ? rev : fwd ^ rev \
+)
+
+#define WORDSIZE 5
+#define SEED1 42
+#define SEED2 1985
+#define HASHBITS 64
+
+int main(int argc, char * argv[])
+{
+    // With word size k=5, a DNA sequence with 7 nucleotides has 3 k-mers.
+    string input = "GATTACA";
+    string kmer1 = "GATTA";
+    string kmer2 = "ATTAC";
+    string kmer3 = "TTACA";
+
+    // Initialize the hash function to compute the hash of the first k-mer.
+    CyclicHash<uint64_t> forward(WORDSIZE, SEED1, SEED2, HASHBITS);
+    CyclicHash<uint64_t> reverse(WORDSIZE, SEED1, SEED2, HASHBITS);
+    for (int j = 0; j < 4; j++) {
+        forward.eat(input[j]);
+        reverse.eat(nucleotide_complement(input[3 - j]));
+    }
+    uint64_t hashval = canonical_hash(forward.hashvalue, reverse.hashvalue);
+    std::cout << kmer1 << ' ' << hashval << '\n';
+
+    // Now do rolling updates to the hash.
+    forward.update('G', 'C');
+    reverse.reverse_update(nucleotide_complement('G'), nucleotide_complement('C'));
+    hashval = canonical_hash(forward.hashvalue, reverse.hashvalue);
+    std::cout << kmer2 << ' ' << hashval << '\n';
+
+    forward.update('A', 'A');
+    reverse.reverse_update(nucleotide_complement('A'), nucleotide_complement('A'));
+    hashval = canonical_hash(forward.hashvalue, reverse.hashvalue);
+    std::cout << kmer3 << ' ' << hashval << '\n';
+
+    // Finally, test that the rolling updates gives us the same hash as
+    // initializing the third k-mer from scratch.
+    CyclicHash<uint64_t> forward_test(WORDSIZE, SEED1, SEED2, HASHBITS);
+    CyclicHash<uint64_t> reverse_test(WORDSIZE, SEED1, SEED2, HASHBITS);
+    for (int j = 0; j < 4; j++) {
+        forward_test.eat(kmer3[j]);
+        reverse_test.eat(nucleotide_complement(kmer3[3 - j]));
+    }
+    uint64_t testhashval = canonical_hash(forward_test.hashvalue, reverse_test.hashvalue);
+    std::cout << "Test: " << hashval << " == " << testhashval << " ?\n";
+    assert(testhashval == hashval);
+
+    return 0;
+}


### PR DESCRIPTION
I did a cursory evaluation of this rolling hash implementation for [khmer](http://github.com/dib-lab/khmer) back in May. Thank you for your comments at the time! After focusing on other things in the mean time, I'm returning to see if we can get this code to do what we need.

One of the issues was seeding. The random number generator has always been seedable, but this wasn't well exposed throughout the API. This pull request addresses this concern, although I'd welcome feedback/critique on the proposed solution.

Another issue is application-specific and has to do with the nature of DNA. Even though we usually represent DNA as a string of characters (such as `GATTACA`), this is really only half the story. DNA is double stranded with `A` pairing to `T` and `C` pairing to `G`, so the string `GATTACA` really represents the following molecule.

```
gattaca
|||||||
ɔʇɐɐʇƃʇ
```

In most contexts, we have no way of knowing whether the original piece of DNA sampled was from the top strand or the bottom strand, and so when we hash DNA sequences we typically want the two complementary sequences to hash to the same value.

This PR also adds a new example (`example5.cpp`) where I've tried to demonstrate the desired behavior. I used two cyclic hashes: one for the "top" strand of DNA (observed from the provided string, updated using forward updates) and one for the "bottom" strand (inferred from the provided string, updated using reverse updates). Then to get the hash for a particular k-mer (n-gram) in the DNA, I just XOR the current forward and reverse hashes.

Unfortunately, it doesn't seem to be working as expected. I don't know if this is because I made a mistake in the code, or if there's something I'm still not understanding. Any comments you might have would be welcome.

P.S. Apologies if the contributors to this code are well-versed in bioinformatics. I figured it would be safer to assume otherwise and to describe the problem in layman's terms. Thanks!