### PR TITLE
Add RabinKarpHashBits, which templates hash word size

### DIFF
--- a/characterhash.h
+++ b/characterhash.h
@@ -36,7 +36,10 @@ private:
 };
 
 template <typename hashvaluetype>
-constexpr hashvaluetype maskfnc(int bits) {
+#if __cplusplus >= 201402L
+constexpr
+#endif
+hashvaluetype maskfnc(int bits) {
     assert(bits>0);
     assert(bits<=sizeof(hashvaluetype)*8);
     hashvaluetype x = static_cast<hashvaluetype>(1) << (bits - 1);

--- a/rabinkarphash.h
+++ b/rabinkarphash.h
@@ -3,6 +3,8 @@
 
 
 #include "characterhash.h"
+#include <cstring>
+
 
 
 /**
@@ -107,7 +109,13 @@ public:
     }
     template<typename T>
     void mask_value(T &val) const {
-        if constexpr(!is_full_word()) val &= HASHMASK;
+#if __cplusplus >= 201703L
+#define CONSTIF if constexpr
+#else
+#define CONSTIF if
+#endif
+        CONSTIF(!is_full_word()) val &= HASHMASK;
+#undef CONSTIF
     }
 
     // this is a convenience function, use eat,update and .hashvalue to use as a rolling hash function


### PR DESCRIPTION
This eliminates mask operations for the cases where hash size is equal to the size of the type.
Additionally, maskfnc is now `constexpr`.